### PR TITLE
ci(publish): install libsecret-1-dev for keytar native module (continues #8)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install system deps for keytar (libsecret)
+        run: sudo apt-get update && sudo apt-get install -y libsecret-1-dev
+
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:


### PR DESCRIPTION
Adds apt-get install libsecret-1-dev step before pnpm install. Resolves ERR_DLOPEN_FAILED on keytar native module that surfaced after PR #11 excluded fix-e2e.test.ts.

Fix-chain on issue #8 — RCA still ongoing post-launch.