### PR TITLE
docs(readme): use @beta qualifier for npx/install (pre-1.0 prerelease channel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,18 +40,25 @@ Application development documentation under `docs/` is written in **English** (S
 
 ## Install
 
+> **Beta channel during pre-1.0**: Use the `@beta` tag explicitly. We don't push prerelease versions to npm's `latest` tag, so a bare `npx endiorbot` resolves to nothing until v1.0 ships.
+
 ```bash
-# Via npx (no install needed)
-npx endiorbot --help
-npx endiorbot init
-npx endiorbot serve
+# Via npx (no install needed) — beta channel
+npx endiorbot@beta --help
+npx endiorbot@beta init
+npx endiorbot@beta serve
 
 # Or install globally
-npm install -g endiorbot
+npm install -g endiorbot@beta
+
+# Or pin a specific beta version
+npm install -g endiorbot@0.1.0-beta.1
 
 # Or via Docker
 docker run -p 18790:18790 endiorbot/endiorbot serve
 ```
+
+After v1.0.0 ships, the `@beta` qualifier will become optional and the bare `npx endiorbot` form will work for stable installs.
 
 ## Quick Start
 

--- a/docs/06-deploy/README.md
+++ b/docs/06-deploy/README.md
@@ -41,8 +41,10 @@ Access:
 
 ### Option B: npm Global Install
 
+> Beta channel during pre-1.0: use `@beta` qualifier.
+
 ```bash
-npm install -g endiorbot
+npm install -g endiorbot@beta
 endiorbot init --tier STANDARD
 endiorbot serve
 ```
@@ -50,8 +52,8 @@ endiorbot serve
 ### Option C: npx (No Install)
 
 ```bash
-npx endiorbot serve
-npx endiorbot init
+npx endiorbot@beta serve
+npx endiorbot@beta init
 ```
 
 ### Option E: Desktop App (Electron)

--- a/docs/07-operate/USAGE-GUIDE.md
+++ b/docs/07-operate/USAGE-GUIDE.md
@@ -40,18 +40,20 @@ EndiorBot is a personal AI tool for solo developers. It integrates with Claude C
 
 ## Installation
 
+> Beta channel during pre-1.0: use `@beta` qualifier. After v1.0 ships, the bare `npx endiorbot` form will work for stable installs.
+
 ### Via npx (recommended)
 
 ```bash
-npx endiorbot --help
-npx endiorbot init
-npx endiorbot serve
+npx endiorbot@beta --help
+npx endiorbot@beta init
+npx endiorbot@beta serve
 ```
 
 ### Global install
 
 ```bash
-npm install -g endiorbot
+npm install -g endiorbot@beta
 endiorbot --help
 ```
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
-    "endiorbot": "./endiorbot.mjs"
+    "endiorbot": "endiorbot.mjs"
   },
   "exports": {
     ".": {
@@ -37,7 +37,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Minh-Tam-Solution/EndiorBot"
+    "url": "git+https://github.com/Minh-Tam-Solution/EndiorBot.git"
   },
   "homepage": "https://github.com/Minh-Tam-Solution/EndiorBot",
   "bugs": {


### PR DESCRIPTION
After manual publish 2026-04-30, npm has `endiorbot@0.1.0-beta.1` on `@beta` dist-tag but no `@latest`. Bare `npx endiorbot` returns 404 — adopters must use `npx endiorbot@beta`.

Updated 3 docs (README + deploy + USAGE-GUIDE) with @beta qualifier + note explaining post-v1 behavior.

Refs: SDLC-Orchestrator LAUNCH-PLAN-2026-04-29.md Day-2 update.