### PR TITLE
fix: issue #8 RCA — session-handoff mtime-tie + fix-e2e helper improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install system deps for keytar (libsecret)
+        run: sudo apt-get update && sudo apt-get install -y libsecret-1-dev
+
       - name: Build
         run: pnpm build
 
       - name: Test (with retry for flaky gateway port contention)
-        run: pnpm test --pool=forks --retry=2
+        # Note the `--` separator: passes flags to vitest, not pnpm.
+        # Without it, pnpm intercepts `--pool` and `--retry` as pnpm options.
+        run: pnpm test -- --pool=forks --retry=2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,17 +36,7 @@ jobs:
         run: pnpm build
 
       - name: Test
-        # Excluding 2 test files pending issue #8 RCA (target v0.1.0-beta.2):
-        # 1. tests/cli/commands/fix-e2e.test.ts — passes 14/14 locally,
-        #    fails deterministically in CI Docker (exitCode=1 vs 0).
-        # 2. tests/integration/sprint-101-tier-routing-clawvault.test.ts —
-        #    loadLatestHandoff returns wrong session in CI; suspected mtime-
-        #    sort race when 2 file writes occur in same millisecond on fast CI.
-        # Other 8108+ tests still run + must pass.
-        run: |
-          pnpm vitest run \
-            --exclude 'tests/cli/commands/fix-e2e.test.ts' \
-            --exclude 'tests/integration/sprint-101-tier-routing-clawvault.test.ts'
+        run: pnpm test
 
       - name: Dry-run pack (verify files whitelist)
         run: npm pack --dry-run

--- a/src/memory/session-handoff.ts
+++ b/src/memory/session-handoff.ts
@@ -65,8 +65,19 @@ export function saveHandoff(projectId: string, handoff: SessionHandoff): void {
 
 /**
  * Load the most recent handoff document for a project.
- * Uses filesystem mtime to find the newest file — O(1) reads instead of O(n).
- * (CTO F1: loadLatestHandoff perf optimization)
+ *
+ * Uses mtime as a fast-path heuristic to identify a probable newest file,
+ * then falls back to scanning all files by `createdAt` if there are mtime
+ * ties (e.g., multiple writes in the same millisecond on fast filesystems).
+ *
+ * The mtime fast-path covers the common case (1 file or clear mtime ordering).
+ * The createdAt scan handles the edge case (file mtimes equal — would
+ * non-deterministically return the first iterated file otherwise).
+ *
+ * Aligned with `loadAllHandoffs` semantics (which sorts by `createdAt`).
+ *
+ * Refs: issue #8 — CI Docker writes occur within same millisecond, mtime
+ * ties produce wrong result. Fixed by createdAt tiebreaker.
  *
  * @param projectId - Project identifier
  * @returns Latest SessionHandoff or null if none exists
@@ -79,21 +90,57 @@ export function loadLatestHandoff(projectId: string): SessionHandoff | null {
   const files = readdirSync(handoffDir).filter((f) => f.endsWith(".json"));
   if (files.length === 0) return null;
 
-  // Find newest file by mtime — avoids reading all files (CTO F1)
+  // Fast path: 1 file → just read it
+  if (files.length === 1) {
+    try {
+      const content = readFileSync(join(handoffDir, files[0]!), "utf-8");
+      return JSON.parse(content) as SessionHandoff;
+    } catch {
+      return null;
+    }
+  }
+
+  // Find newest file by mtime, tracking ties for fallback
   let newestFile = files[0]!;
-  let newestMtime = 0;
+  let newestMtime = -1;
+  let mtimeTie = false;
   for (const file of files) {
     try {
       const mtime = statSync(join(handoffDir, file)).mtimeMs;
       if (mtime > newestMtime) {
         newestMtime = mtime;
         newestFile = file;
+        mtimeTie = false;
+      } else if (mtime === newestMtime && file !== newestFile) {
+        mtimeTie = true;
       }
     } catch {
       // Skip files we can't stat
     }
   }
 
+  // Fallback: if any mtime tie at the top, scan by createdAt to break it
+  // deterministically (consistent with loadAllHandoffs semantics).
+  if (mtimeTie) {
+    let newestByCreatedAt: SessionHandoff | null = null;
+    for (const file of files) {
+      try {
+        const content = readFileSync(join(handoffDir, file), "utf-8");
+        const handoff = JSON.parse(content) as SessionHandoff;
+        if (
+          newestByCreatedAt === null ||
+          handoff.createdAt.localeCompare(newestByCreatedAt.createdAt) > 0
+        ) {
+          newestByCreatedAt = handoff;
+        }
+      } catch {
+        // Skip malformed
+      }
+    }
+    return newestByCreatedAt;
+  }
+
+  // Common path: mtime winner is unambiguous
   try {
     const content = readFileSync(join(handoffDir, newestFile), "utf-8");
     return JSON.parse(content) as SessionHandoff;

--- a/tests/cli/commands/fix-e2e.test.ts
+++ b/tests/cli/commands/fix-e2e.test.ts
@@ -21,11 +21,11 @@ import { tmpdir } from "node:os";
 // Test Setup
 // ============================================================================
 
-// Bump testTimeout to 60s for this file: spawnSync calls have a 30s internal
-// timeout but vitest's default 10s would kill the test before spawnSync returns,
-// producing exitCode=1 (process killed) instead of the actual CLI exit code.
-// CI Docker scheduling is slower than dev machines — issue #8 RCA.
-vi.setConfig({ testTimeout: 60_000, hookTimeout: 60_000 });
+// Bump testTimeout to 120s for this file: each test may invoke runCli multiple
+// times; CI cold-start of node + endiorbot.mjs + dist bundle takes 5-15s in
+// Docker per spawn. Test budget = 120s (4 spawns × 30s). spawnSync timeout
+// independently set to 60s. Issue #8 RCA.
+vi.setConfig({ testTimeout: 120_000, hookTimeout: 120_000 });
 
 const CLI_PATH = join(process.cwd(), "endiorbot.mjs");
 
@@ -38,11 +38,16 @@ function createTempDir(): string {
 
 /**
  * Run CLI command and return output.
+ *
+ * Distinguishes spawn errors / signal kills / real exit codes so test
+ * failures surface the actual cause (issue #8 RCA: previously
+ * `result.status ?? 1` masked killed-by-signal as exitCode=1, indistinguishable
+ * from CLI's own exit-1).
  */
 function runCli(
   args: string[],
   options: { input?: string; cwd?: string; env?: Record<string, string> } = {}
-): { stdout: string; stderr: string; exitCode: number } {
+): { stdout: string; stderr: string; exitCode: number; signal: NodeJS.Signals | null; error: Error | null } {
   const result = spawnSync(process.execPath, [CLI_PATH, ...args], {
     encoding: "utf-8",
     input: options.input,
@@ -53,13 +58,34 @@ function runCli(
       // Prevent interactive prompts
       CI: "true",
     },
-    timeout: 30000,
+    timeout: 60_000,
   });
 
+  const stdout = result.stdout || "";
+  const stderr = result.stderr || "";
+
+  // Surface debug context when CI=true and exit is not clean (status null = signal/timeout/error)
+  if (process.env.CI === "true" && result.status === null) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `[runCli debug] non-clean exit:\n` +
+        `  args:    ${JSON.stringify(args)}\n` +
+        `  cwd:     ${options.cwd || process.cwd()}\n` +
+        `  status:  ${result.status}\n` +
+        `  signal:  ${result.signal}\n` +
+        `  error:   ${result.error?.message || "none"}\n` +
+        `  stdout:  ${stdout.slice(0, 500)}\n` +
+        `  stderr:  ${stderr.slice(0, 500)}`
+    );
+  }
+
   return {
-    stdout: result.stdout || "",
-    stderr: result.stderr || "",
-    exitCode: result.status ?? 1,
+    stdout,
+    stderr,
+    // status is null when killed by signal or timeout — surface separately
+    exitCode: result.status ?? -1,
+    signal: result.signal ?? null,
+    error: result.error ?? null,
   };
 }
 


### PR DESCRIPTION
## RCA + fix for issue #8 (CI test flake — un-exclude 2 test files)

3 coordinated changes:

### 1. `src/memory/session-handoff.ts` — loadLatestHandoff mtime-tie bug
Used `mtimeMs` for newest file → ties on fast CI filesystems → wrong file.
Fix: mtime fast-path with `createdAt` fallback on tie. Aligns with `loadAllHandoffs` semantics.

### 2. `tests/cli/commands/fix-e2e.test.ts` — runCli helper improvements
- `result.status ?? 1` → `?? -1` (don't mask signal-killed as exit-1)
- spawnSync timeout 30s → 60s (CI cold-start)
- testTimeout 60s → 120s (4-spawn loop budget)
- Debug logging for non-clean exits in CI

### 3. `.github/workflows/publish.yml` — un-exclude both test files
Reverts the workaround from PRs #11 + #13.

## Verification
- Local: 14/14 fix-e2e + 33/33 sprint-101 PASS
- CI: pending validation via this PR's ci.yml run

## After merge
- Cut v0.1.0-beta.2 release → publish.yml runs full suite + publishes to npm

Closes #8